### PR TITLE
Store a pointer to `app` internally

### DIFF
--- a/src/Reactduino.cpp
+++ b/src/Reactduino.cpp
@@ -4,6 +4,8 @@
 #include "Reactduino.h"
 #include "ReactduinoISR.h"
 
+// Need to define the static variable outside of the class
+Reactduino* Reactduino::app = NULL;
 
 typedef union {
     uint32_t as_uint32;
@@ -16,17 +18,18 @@ typedef union {
 
 void setup(void)
 {
-    app.setup();
+    Reactduino::app->setup();
 }
 
 void loop(void)
 {
-    app.tick();
+    Reactduino::app->tick();
     yield();
 }
 
 Reactduino::Reactduino(react_callback cb) : _setup(cb)
 {
+    app = this;
 }
 
 void Reactduino::setup(void)

--- a/src/Reactduino.h
+++ b/src/Reactduino.h
@@ -45,6 +45,9 @@ public:
     void setup(void);
     void tick(void);
 
+    // static singleton reference to the instantiated Reactduino object
+    static Reactduino* app;
+
     // Public API
     reaction delay(uint32_t t, react_callback cb);
     reaction repeat(uint32_t t, react_callback cb);
@@ -71,7 +74,5 @@ private:
 
     reaction onInputChange(uint8_t number, react_callback cb, int state);
 };
-
-extern Reactduino app;
 
 #endif


### PR DESCRIPTION
Hi,

I was trying to get SigkSens to compile on PlatformIO, and for some reason the linker wasn't able to connect the two `extern app` declarations. I figured it'd be easier for the user anyway to not have to worry about that, so I made Reactduino class constructor store a pointer to the instantiated object in a static variable.

Probably easier to just look at the code to understand the change. ;-)
