### PR TITLE
Bugfix: Shouldn't automatically free delay reactions

### DIFF
--- a/src/Reactduino.cpp
+++ b/src/Reactduino.cpp
@@ -51,7 +51,7 @@ void Reactduino::tick(void)
                 elapsed = now - r_entry.param1;
 
                 if (elapsed >= r_entry.param2) {
-                    free(r);
+                    disable(r);
                     r_entry.cb();
                 }
 
@@ -72,7 +72,7 @@ void Reactduino::tick(void)
             }
 
             case REACTION_TYPE_STREAM: {
-                Stream *stream;
+                Stream * stream;
 
                 stream = (Stream *) r_entry.ptr;
 
@@ -151,7 +151,7 @@ reaction Reactduino::repeat(uint32_t t, react_callback cb)
     return r;
 }
 
-reaction Reactduino::onAvailable(Stream *stream, react_callback cb)
+reaction Reactduino::onAvailable(Stream * stream, react_callback cb)
 {
     reaction r;
 

--- a/src/Reactduino.h
+++ b/src/Reactduino.h
@@ -33,7 +33,7 @@ typedef int32_t reaction;
 
 typedef struct reaction_entry_t_ {
     uint8_t flags;
-    void *ptr;
+    void * ptr;
     uint32_t param1, param2;
     react_callback cb;
 } reaction_entry_t;
@@ -48,7 +48,7 @@ public:
     // Public API
     reaction delay(uint32_t t, react_callback cb);
     reaction repeat(uint32_t t, react_callback cb);
-    reaction onAvailable(Stream *stream, react_callback cb);
+    reaction onAvailable(Stream * stream, react_callback cb);
     reaction onInterrupt(uint8_t number, react_callback cb, int mode);
     reaction onPinRising(uint8_t pin, react_callback cb);
     reaction onPinFalling(uint8_t pin, react_callback cb);


### PR DESCRIPTION
Free'ing a delay reaction automatically could cause a problem if the reaction is later reallocated and then unintentionally free'd in an attempt to cleanly dispose of the first (original) reaction.

The solution is to disable the reaction, and leave the consumer to clean up the reaction if they want to reuse it.

This is a backwards incompatible change, as any code that relied upon this as a feature will now break.