### PR TITLE
[bug] Delay function runs immediately

### DIFF
--- a/src/Reactduino.cpp
+++ b/src/Reactduino.cpp
@@ -35,10 +35,10 @@ void Reactduino::setup(void)
 void Reactduino::tick(void)
 {
     reaction r;
-    uint32_t now = millis();    
 
     for (r = 0; r < _top; r++) {
         reaction_entry_t& r_entry = _table[r];
+        uint32_t now = millis();
 
         if (!(r_entry.flags & REACTION_FLAG_ALLOCATED) || !(r_entry.flags & REACTION_FLAG_ENABLED)) {
             continue;


### PR DESCRIPTION
If one of the callbacks blocks for a period of time and creates a delay timer, the delay timer will run immediately.

The answer is to make sure we retrieve the `millis()` clock time for each reaction poll.